### PR TITLE
warning not given

### DIFF
--- a/tests/testthat/test-cellnumbers.R
+++ b/tests/testthat/test-cellnumbers.R
@@ -15,7 +15,7 @@ test_that("cell numbers for points works", {
   expect_identical(raster_tib$cell_, tabula_tib$cell_)
   expect_silent(aa <- cellnumbers(ghrsst, sfc)$cell_)
   expect_equal(aa, NA_integer_)
-  expect_warning(cellnumbers(ghrsst, sfc[[1]]), "the condition has length > 1")
+  #expect_warning(cellnumbers(ghrsst, sfc[[1]]), "the condition has length > 1")
   expect_null(mat2d_f(NULL))
 })
 


### PR DESCRIPTION
I think you are testing for a warning that was not intentional when the class is more than one character string. The warning has now disappeared from the development of raster. I think it came from (class(object) == "")  and that this changed to inherits(object, "") or something like that